### PR TITLE
fix: build ttyd 1.6.1 with libwebsockets 3.2.3

### DIFF
--- a/src/ai/backend/krunner/alpine/ttyd_linux.x86_64.bin
+++ b/src/ai/backend/krunner/alpine/ttyd_linux.x86_64.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61b5c90e588816fa835aaf5eef2347175af21862bb4db9bd170246fed905464f
-size 2243488
+oid sha256:7fa9f27e4389bd992ecf24f9f3caffa7f1257df9f381fe0c52e9e980e4bc1c4d
+size 3532424


### PR DESCRIPTION
libwebsockets>=4.0.0 features auto ping/pong with 5 min default interval.
(https://github.com/warmcat/libwebsockets#connection-validity-tracking)
And, ws_ping_pong_interval of ttyd is not effective in
libwebsockets>=4.0.0. This seems to be the reason why ttyd>=1.6.1 does
not set ws_ping_pong_interval for libwebsockets>=4.0.0.
(https://github.com/tsl0922/ttyd/blob/master/src/server.c#L456)

But, our WSProxy sever TCP connection if there is no data transfer for
30 seconds, which is far less than 5 min. This causes periodic blinking
of ttyd terminal.

To fix this, we build ttyd==1.6.1 with libwebsockets==3.2.3, for now.